### PR TITLE
When generating an NX crash, previously the code would explicitly jump...

### DIFF
--- a/CrashProbe/CRLCrashNXPage.m
+++ b/CrashProbe/CRLCrashNXPage.m
@@ -33,13 +33,20 @@
 - (NSString *)title { return @"Jump into an NX page"; }
 - (NSString *)desc { return @"Call a function pointer to memory in a non-executable page."; }
 
-- (void)crash
+static void __attribute__((noinline)) real_NXcrash(void)
 {
 	void *ptr = mmap(NULL, (size_t)getpagesize(), PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
 	
 	if (ptr != MAP_FAILED) {
         ((void (*)(void))ptr)();
     }
+    
+    munmap(ptr, (size_t)getpagesize());
+}
+
+- (void)crash
+{
+    real_NXcrash();
 }
 
 @end

--- a/CrashProbe/CRLCrashNXPage.m
+++ b/CrashProbe/CRLCrashNXPage.m
@@ -25,6 +25,7 @@
  */
 
 #import "CRLCrashNXPage.h"
+#import <sys/mman.h>
 
 @implementation CRLCrashNXPage
 
@@ -34,7 +35,11 @@
 
 - (void)crash
 {
-   ((void (*)(void))NULL)();
+	void *ptr = mmap(NULL, (size_t)getpagesize(), PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+	
+	if (ptr != MAP_FAILED) {
+        ((void (*)(void))ptr)();
+    }
 }
 
 @end


### PR DESCRIPTION
to NULL, which modern versions of Clang correctly optimize out as provable undefined behavior (the compiler is free to do whatever it wants if it can prove that the code will always dereference NULL). Instead, map a valid memory space without the execute permission and jump to that pointer.