### PR TITLE
Add value for runpath search paths...

### DIFF
--- a/CrashProbe.xcodeproj/project.pbxproj
+++ b/CrashProbe.xcodeproj/project.pbxproj
@@ -1232,6 +1232,7 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-fno-optimize-sibling-calls";
@@ -1311,6 +1312,7 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "-fno-optimize-sibling-calls";


### PR DESCRIPTION
...for CrashProbe for Mac. Xcode should add the value when dragging and dropping a .framework into the project navigator but it doesn't for some reason.

This PR adds the value that's necessary.